### PR TITLE
Enable support for users who swap out Django's auth.User for their own m...

### DIFF
--- a/conversation/forms.py
+++ b/conversation/forms.py
@@ -1,7 +1,7 @@
 """Forms for the ``conversation`` app."""
 from django import forms
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.db.models import Q
 
 from .models import Conversation, Message
@@ -16,7 +16,7 @@ class MessageForm(forms.ModelForm):
         self.content_object = content_object
         super(MessageForm, self).__init__(*args, **kwargs)
         if not self.conversation:
-            users = User.objects.exclude(pk=user.pk)
+            users = get_user_model().objects.exclude(pk=user.pk)
             self.fields['recipients'] = forms.MultipleChoiceField(
                 choices=[(u.pk, u) for u in users],
                 initial=([initial_user.pk] if initial_user else ''),
@@ -28,7 +28,7 @@ class MessageForm(forms.ModelForm):
             self.instance.user = self.user
             if not self.conversation:
                 # Check for existing conversations of these users
-                recipients = User.objects.filter(
+                recipients = get_user_model().objects.filter(
                     Q(pk__in=self.cleaned_data['recipients'])
                     | Q(pk=self.user.pk),
                 )

--- a/conversation/migrations/0001_initial.py
+++ b/conversation/migrations/0001_initial.py
@@ -5,6 +5,7 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
+from ..compat import USER_MODEL
 
 class Migration(SchemaMigration):
 
@@ -20,14 +21,14 @@ class Migration(SchemaMigration):
         db.create_table(m2m_table_name, (
             ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
             ('conversation', models.ForeignKey(orm[u'conversation.conversation'], null=False)),
-            ('user', models.ForeignKey(orm[u'auth.user'], null=False))
+            ('user', models.ForeignKey(USER_MODEL['orm_label'], null=False))
         ))
         db.create_unique(m2m_table_name, ['conversation_id', 'user_id'])
 
         # Adding model 'Message'
         db.create_table(u'conversation_message', (
             (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-            ('user', self.gf('django.db.models.fields.related.ForeignKey')(related_name='messages', to=orm['auth.User'])),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(related_name='messages', to=USER_MODEL['orm_label'])),
             ('conversation', self.gf('django.db.models.fields.related.ForeignKey')(related_name='messages', to=orm['conversation.Conversation'])),
             ('date', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
             ('text', self.gf('django.db.models.fields.TextField')(max_length=2048)),
@@ -60,8 +61,8 @@ class Migration(SchemaMigration):
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
         },
-        u'auth.user': {
-            'Meta': {'object_name': 'User'},
+        USER_MODEL['model_label']: {
+            'Meta': {'object_name': USER_MODEL['object_name']},
             'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
             'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
             'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
@@ -86,7 +87,7 @@ class Migration(SchemaMigration):
         u'conversation.conversation': {
             'Meta': {'object_name': 'Conversation'},
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'users': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'conversations'", 'symmetrical': 'False', 'to': u"orm['auth.User']"})
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'conversations'", 'symmetrical': 'False', 'to': u"orm['%s']" % USER_MODEL['orm_label']})
         },
         u'conversation.message': {
             'Meta': {'object_name': 'Message'},
@@ -94,7 +95,7 @@ class Migration(SchemaMigration):
             'date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'text': ('django.db.models.fields.TextField', [], {'max_length': '2048'}),
-            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'messages'", 'to': u"orm['auth.User']"})
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'messages'", 'to': u"orm['%s']" % USER_MODEL['orm_label']})
         }
     }
 

--- a/conversation/migrations/0002_auto.py
+++ b/conversation/migrations/0002_auto.py
@@ -75,10 +75,10 @@ class Migration(SchemaMigration):
         },
         u'conversation.conversation': {
             'Meta': {'object_name': 'Conversation'},
-            'archived_by': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'archived_conversations'", 'symmetrical': 'False', 'to': u"orm['auth.User']"}),
+            'archived_by': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'archived_conversations'", 'symmetrical': 'False', 'to': u"orm['%s']" % USER_MODEL['orm_label']}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'read_by': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'read_conversations'", 'symmetrical': 'False', 'to': u"orm['auth.User']"}),
-            'users': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'conversations'", 'symmetrical': 'False', 'to': u"orm['auth.User']"})
+            'read_by': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'read_conversations'", 'symmetrical': 'False', 'to': u"orm['%s']" % USER_MODEL['orm_label']}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'conversations'", 'symmetrical': 'False', 'to': u"orm['%s']" % USER_MODEL['orm_label']})
         },
         u'conversation.message': {
             'Meta': {'object_name': 'Message'},
@@ -86,7 +86,7 @@ class Migration(SchemaMigration):
             'date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'text': ('django.db.models.fields.TextField', [], {'max_length': '2048'}),
-            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'messages'", 'to': u"orm['auth.User']"})
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'messages'", 'to': u"orm['%s']" % USER_MODEL['orm_label']})
         }
     }
 

--- a/conversation/migrations/0003_auto__add_field_conversation_content_type__add_field_conversation_obje.py
+++ b/conversation/migrations/0003_auto__add_field_conversation_content_type__add_field_conversation_obje.py
@@ -67,12 +67,12 @@ class Migration(SchemaMigration):
         },
         u'conversation.conversation': {
             'Meta': {'object_name': 'Conversation'},
-            'archived_by': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'archived_conversations'", 'symmetrical': 'False', 'to': u"orm['auth.User']"}),
+            'archived_by': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'archived_conversations'", 'symmetrical': 'False', 'to': u"orm['%s']" % USER_MODEL['orm_label']}),
             'content_type': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'conversation_content_objects'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'object_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
-            'read_by': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'read_conversations'", 'symmetrical': 'False', 'to': u"orm['auth.User']"}),
-            'users': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'conversations'", 'symmetrical': 'False', 'to': u"orm['auth.User']"})
+            'read_by': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'read_conversations'", 'symmetrical': 'False', 'to': u"orm['%s']" % USER_MODEL['orm_label']}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'conversations'", 'symmetrical': 'False', 'to': u"orm['%s']" % USER_MODEL['orm_label']})
         },
         u'conversation.message': {
             'Meta': {'object_name': 'Message'},
@@ -80,7 +80,7 @@ class Migration(SchemaMigration):
             'date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'text': ('django.db.models.fields.TextField', [], {'max_length': '2048'}),
-            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'messages'", 'to': u"orm['auth.User']"})
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'messages'", 'to': u"orm['%s']" % USER_MODEL['orm_label']})
         }
     }
 

--- a/conversation/models.py
+++ b/conversation/models.py
@@ -2,6 +2,7 @@
 from django.contrib.contenttypes import generic
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
+from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -16,19 +17,19 @@ class Conversation(models.Model):
 
     """
     users = models.ManyToManyField(
-        'auth.User',
+        settings.AUTH_USER_MODEL,
         verbose_name=_('Users'),
         related_name='conversations',
     )
 
     archived_by = models.ManyToManyField(
-        'auth.User',
+        settings.AUTH_USER_MODEL,
         verbose_name=_('Archived by'),
         related_name='archived_conversations',
     )
 
     read_by = models.ManyToManyField(
-        'auth.User',
+        settings.AUTH_USER_MODEL,
         verbose_name=_('Read by'),
         related_name='read_conversations',
     )
@@ -54,7 +55,7 @@ class Message(models.Model):
 
     """
     user = models.ForeignKey(
-        'auth.User',
+        settings.AUTH_USER_MODEL,
         verbose_name=_('User'),
         related_name='messages',
     )


### PR DESCRIPTION
...odel

https://docs.djangoproject.com/en/1.7/topics/auth/customizing/#substituting-a-custom-user-model

allows developers to replace django's auth.User with their custom models, would be great to get this feature in your wonderful project